### PR TITLE
Fix commands

### DIFF
--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -154,22 +154,9 @@ module.exports =
   addToBacklog: -> @moveTodoToBottomOfSection('Backlog')
 
   createTodo: ->
-    console.log("Creating todo")
     editor = @getEditor()
-    curLine = editor.getCursorBufferPosition()
-    range = [[0,0], editor.getEofBufferPosition()]
-    headerRegex = _.escapeRegExp(todoHeaderString)
-    editor.scanInBufferRange new RegExp(headerRegex, 'g'), range, (result) ->
-      result.stop()
-      footerRegex = _.escapeRegExp(footerString)
-      range = [result.range.end, editor.getEofBufferPosition()]
-      editor.scanInBufferRange new RegExp(footerRegex, 'g'), range, (footerResult) ->
-        footerResult.stop()
-        editor.setCursorBufferPosition(footerResult.range.start)
-        editor.moveLeft()
-        editor.insertNewline()
-        editor.moveToBeginningOfLine()
-        editor.insertText('  ')
+    @moveCursorToSection(editor, 'Backlog', 'footer')
+    editor.insertNewlineAbove()
     return true
 
   closeTodo: ->

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -83,7 +83,7 @@ module.exports =
       editor.transact =>
         if !fn.call(@) then editor.abortTransaction()
 
-  selectTodo: -> @attempt(-> @moveTodoToTopOfSection 'Todo')
+  selectTodo: -> @attempt(-> @moveTodoToSection 'Todo')
 
   doneTodo: -> @attempt(@closeTodo)
 
@@ -108,9 +108,6 @@ module.exports =
     editor.selectToBeginningOfLine()
     todo = editor.getSelectedText()
     return { 'text': todo, 'position': origPos}
-
-  moveTodoToTopOfSection: (section, prefix) -> @moveTodoToSection(section, false, prefix)
-  moveTodoToBottomOfSection: (section, prefix) -> @moveTodoToSection(section, true, prefix)
 
   moveTodoToSection: (section, bottom, prefix) ->
     @copyTodoToSection(section, bottom, prefix)
@@ -164,7 +161,7 @@ module.exports =
 
   closeTodo: ->
     closedTime = ("~(#{moment().format(atom.config.get('gpd.dateFormat'))}) ")
-    return @moveTodoToTopOfSection("Closed", closedTime)
+    return @moveTodoToSection("Closed", closedTime)
 
   # Create a new note section with boilerplate text in the view supplied
   createNote: (noteTime, todoStr) ->

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -115,7 +115,7 @@ module.exports =
      todo = line.text.replace(/(^\s+|\s+$)/g,'') # Trim
      if !@isHeader(todo)
        @deleteLine()
-       @moveCursorToSectionHeader(section)
+       @moveCursorToSection(editor, section)
        editor.insertNewline()
        editor.moveToBeginningOfLine()
        editor.insertText('  ')
@@ -137,7 +137,7 @@ module.exports =
      line = @selectCurrentLine(editor)
      todo = line.text
      if !@isHeader(todo)
-       @moveCursorToSectionFooter(section)
+       @moveCursorToSection(editor, section, 'footer')
        console.log(editor.getCursorBufferPosition())
        editor.moveLeft()
        editor.insertNewline()
@@ -155,29 +155,21 @@ module.exports =
        editor.setCursorBufferPosition(line.position)
        return false
 
-  moveCursorToSectionHeader: (section) ->
-    editor = @getEditor()
-    range = [[0,0], editor.getEofBufferPosition()]
+  moveCursorToSection: (editor, section, footer) ->
     headerRegex = _.escapeRegExp('//' + section + '//')
-    headerPos = editor.getEofBufferPosition()
-    editor.scanInBufferRange new RegExp(headerRegex, 'g'), range, (result) ->
+    editor.scan new RegExp(headerRegex, 'g'), (result) ->
       result.stop()
-      editor.setCursorBufferPosition(result.range.end)
-      headerPos = result.range.end
-    return headerPos
+      if footer
+        moveCursorToEnd(editor, result.range.end)
+      else
+        editor.setCursorBufferPosition(result.range.end)
 
-  moveCursorToSectionFooter: (section) ->
-    editor = @getEditor()
-    headerPos = @moveCursorToSectionHeader(section)
-    console.log(headerPos)
-    range = [headerPos, editor.getEofBufferPosition()]
-    footerRegex = _.escapeRegExp(footerString)
-    footerPos = editor.getEofBufferPosition()
-    editor.scanInBufferRange new RegExp(footerRegex, 'g'), range, (footerResult) ->
-      footerResult.stop()
-      editor.setCursorBufferPosition(footerResult.range.start)
-      footerPos = footerResult.range.start
-    return footerPos
+  moveCursorToEnd: (editor, position) ->
+      footerRegex = _.escapeRegExp(footerString)
+      range = [position, editor.getEofBufferPosition()]
+      editor.scanInBufferRange new RegExp(footerRegex, 'g'), range, (result) ->
+        result.stop()
+        editor.setCursorBufferPosition(result.range.start)
 
   addToBacklog: -> @moveTodoToBottomOfSection('Backlog')
 

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -113,10 +113,13 @@ module.exports =
   moveTodoToBottomOfSection: (section, prefix) -> @moveTodoToSection(section, true, prefix)
 
   moveTodoToSection: (section, bottom, prefix) ->
+    @copyTodoToSection(section, bottom, prefix)
+    @deleteLine()
+
+  copyTodoToSection: (section, bottom, prefix) ->
     editor = @getEditor()
     line = @selectCurrentLine(editor)
     if !@isHeader(line.text)
-      @deleteLine()
       if bottom
         @moveCursorToSection(editor, section, 'footer')
         editor.moveLeft()
@@ -151,7 +154,7 @@ module.exports =
       result.stop()
       editor.setCursorBufferPosition(result.range.start)
 
-  addToBacklog: -> @moveTodoToBottomOfSection('Backlog')
+  addToBacklog: -> @copyTodoToSection('Backlog', 'bottom')
 
   createTodo: ->
     editor = @getEditor()

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -95,13 +95,6 @@ module.exports =
     headerPattern = new RegExp('//(.*)//')
     headerPattern.test(text)
 
-  deleteLine: ->
-    editor = @getEditor()
-    editor.moveToEndOfLine()
-    editor.selectToBeginningOfLine()
-    editor.delete()  # delete line content
-    editor.delete()  # delete newline
-
   selectCurrentLine: (editor) ->
     origPos = editor.getCursorBufferPosition()
     editor.moveToEndOfLine()
@@ -111,7 +104,7 @@ module.exports =
 
   moveTodoToSection: (section, bottom, prefix) ->
     @copyTodoToSection(section, bottom, prefix)
-    @deleteLine()
+    @getEditor().deleteLine()
 
   copyTodoToSection: (section, bottom, prefix) ->
     editor = @getEditor()

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -102,18 +102,16 @@ module.exports =
     editor.delete()  # delete line content
     editor.delete()  # delete newline
 
-  selectCurrentLine: ->
-    editor = @getEditor()
+  selectCurrentLine: (editor) ->
     origPos = editor.getCursorBufferPosition()
     editor.moveToEndOfLine()
-    endOfLine = editor.getCursorBufferPosition()
-    editor.setSelectedBufferRange([[origPos.row,0],endOfLine])
+    editor.selectToBeginningOfLine()
     todo = editor.getSelectedText()
     return { 'text': todo, 'position': origPos}
 
   moveTodoToTopOfSection: (section, prefix) ->
      editor = @getEditor()
-     line = @selectCurrentLine()
+     line = @selectCurrentLine(editor)
      todo = line.text.replace(/(^\s+|\s+$)/g,'') # Trim
      if !@isHeader(todo)
        @deleteLine()
@@ -136,7 +134,7 @@ module.exports =
 
   moveTodoToBottomOfSection: (section, prefix) ->
      editor = @getEditor()
-     line = @selectCurrentLine()
+     line = @selectCurrentLine(editor)
      todo = line.text
      if !@isHeader(todo)
        @moveCursorToSectionFooter(section)

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -89,7 +89,7 @@ module.exports =
 
   newTodo: -> @attempt(@createTodo)
 
-  doneTodoAndRepeat: -> @attempt(-> @addToBacklog && @closeTodo())
+  doneTodoAndRepeat: -> @attempt(-> @addToBacklog() && @closeTodo())
 
   isHeader: (text) ->
     headerPattern = new RegExp('//(.*)//')

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -89,7 +89,7 @@ module.exports =
 
   newTodo: -> @attempt(@createTodo)
 
-  doneTodoAndRepeat: -> @attempt(-> @addToTodo() && @closeTodo())
+  doneTodoAndRepeat: -> @attempt(-> @addToBacklog && @closeTodo())
 
   isHeader: (text) ->
     headerPattern = new RegExp('//(.*)//')
@@ -181,7 +181,7 @@ module.exports =
       footerPos = footerResult.range.start
     return footerPos
 
-  addToTodo: -> @moveTodoToBottomOfSection('Backlog')
+  addToBacklog: -> @moveTodoToBottomOfSection('Backlog')
 
   createTodo: ->
     console.log("Creating todo")

--- a/lib/todos.coffee
+++ b/lib/todos.coffee
@@ -89,7 +89,13 @@ module.exports =
 
   newTodo: -> @attempt(@createTodo)
 
-  doneTodoAndRepeat: -> @attempt(-> @addToBacklog() && @closeTodo())
+  doneTodoAndRepeat: ->
+    @attempt( ->
+      closedTime = ("~(#{moment().format(atom.config.get('gpd.dateFormat'))}) ")
+      @copyTodoToSection('Closed', closedTime)
+      @removeTag('$')
+      @moveTodoToSection('Backlog', 'bottom')
+    )
 
   isHeader: (text) ->
     headerPattern = new RegExp('//(.*)//')
@@ -143,6 +149,14 @@ module.exports =
     editor.scanInBufferRange new RegExp(footerRegex, 'g'), range, (result) ->
       result.stop()
       editor.setCursorBufferPosition(result.range.start)
+
+  removeTag: (tagIndicator) ->
+    editor = @getEditor()
+    line = @selectCurrentLine(editor)
+    regex = _.escapeRegExp(tagIndicator) + "\\(.*?\\)[ ]?"
+    lineWithoutTag = line.text.replace(new RegExp(regex, 'g'), '')
+    editor.insertText(lineWithoutTag)
+    return true
 
   addToBacklog: -> @copyTodoToSection('Backlog', 'bottom')
 


### PR DESCRIPTION
Everything seems to work fine now.

The regex I'm using in the `removeTag` fn is different from the one you were using, but should work to strip any tag:

    regex = _.escapeRegExp(tagIndicator) + "\\(.*?\\)[ ]?"

The only issue I can see with the new regex is that it strips to the next close-parenthesis `)`, so nested parentheses can't be used. This also seems to affect the old regex though.

I don't think there's anything else that needs saying that hasn't already been mentioned in #2.